### PR TITLE
Typo in react-testing-library API

### DIFF
--- a/docs/react-testing-library/api.md
+++ b/docs/react-testing-library/api.md
@@ -32,7 +32,7 @@ afterEach(cleanup)
 
 test('renders a message', () => {
   const { container, getByText } = render(<Greeting />)
-  expect(getbyText('Hello, world!')).toBeInTheDocument()
+  expect(getByText('Hello, world!')).toBeInTheDocument()
   expect(container.firstChild).toMatchInlineSnapshot(`
     <h1>Hello, World!</h1>
   `)


### PR DESCRIPTION
While I was reading the API documentation about react-testing-library, I noticed this small typo that can lead to errors when copy-pasted.

Thanks for this lib and doc 😉