### PR TITLE
setupTestFrameworkScriptFile => setupFilesAfterEnv

### DIFF
--- a/docs/react-testing-library/setup.md
+++ b/docs/react-testing-library/setup.md
@@ -18,9 +18,26 @@ the setup and teardown of tests in individual files. For example, you can ensure
 [`cleanup`](./api#cleanup) is called after each test and import additional
 assertions.
 
-To do this with Jest, you can add the
+To do this with Jest 24, you can add the
 [`setupFilesAfterEnv`](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array)
-option to your Jest config. The setup file can be anywhere, for example
+option to your Jest config.
+
+```javascript
+// jest.config.js
+module.exports = {
+  setupFilesAfterEnv: [
+    'react-testing-library/cleanup-after-each',
+    // ... other setup files ...
+  ],
+  // ... other options ...
+}
+```
+
+### Jest 23
+
+Jest 23 uses the
+[`setupTestFrameworkScriptFile`](https://jestjs.io/docs/en/23.x/configuration#setuptestframeworkscriptfile-string)
+option in your Jest config. This setup file can be anywhere, for example
 `jest.setup.js` or `./utils/setupTests.js`.
 
 If you are using the default setup from create-react-app, this option is set to
@@ -30,7 +47,7 @@ setup code there.
 ```javascript
 // jest.config.js
 module.exports = {
-  setupFilesAfterEnv: [require.resolve('./jest.setup.js')],
+  setupTestFrameworkScriptFile: require.resolve('./jest.setup.js'),
   // ... other options ...
 }
 ```

--- a/docs/react-testing-library/setup.md
+++ b/docs/react-testing-library/setup.md
@@ -19,7 +19,7 @@ the setup and teardown of tests in individual files. For example, you can ensure
 assertions.
 
 To do this with Jest, you can add the
-[`setupTestFrameworkScriptFile`](https://facebook.github.io/jest/docs/en/configuration.html#setuptestframeworkscriptfile-string)
+[`setupFilesAfterEnv`](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array)
 option to your Jest config. The setup file can be anywhere, for example
 `jest.setup.js` or `./utils/setupTests.js`.
 
@@ -30,7 +30,7 @@ setup code there.
 ```javascript
 // jest.config.js
 module.exports = {
-  setupTestFrameworkScriptFile: require.resolve('./jest.setup.js'),
+  setupFilesAfterEnv: [require.resolve('./jest.setup.js')],
   // ... other options ...
 }
 ```


### PR DESCRIPTION
With the Jest 24 release, they've deprecated `setupTestFrameworkScriptFile` in favor of [`setupFilesAfterEnv`](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array), so I thought it would be helpful to update the docs to match.