### PR TITLE
Fix link to the Update Props page

### DIFF
--- a/docs/react-testing-library/api.md
+++ b/docs/react-testing-library/api.md
@@ -167,7 +167,7 @@ const { rerender } = render(<NumberDisplay number={1} />)
 rerender(<NumberDisplay number={2} />)
 ```
 
-[See the examples page](example-update-props)
+[See the examples page](example-update-props.md)
 
 ### `unmount`
 


### PR DESCRIPTION
Hi! :wave: 

Currently, the `See examples page` [here](https://testing-library.com/docs/react-testing-library/api#rerender) is linking to the wrong document. This PR fixes it.

Cheers and thanks for the docs. :smiley: 