### PR TITLE
feat(render): options.wrapper api + customRender usage

### DIFF
--- a/docs/react-testing-library/api.md
+++ b/docs/react-testing-library/api.md
@@ -6,6 +6,12 @@ title: API
 `react-testing-library` re-exports everything from `dom-testing-library` as well
 as these methods:
 
+- [`render`](#act)
+- [`cleanup`](#cleanup)
+- [`act`](#act)
+
+---
+
 ## `render`
 
 ```typescript
@@ -44,19 +50,17 @@ test('renders a message', () => {
 > The [cleanup](#cleanup) function should be called between tests to remove the
 > created DOM nodes and keep the tests isolated.
 
-### `render` Options
-
-<details>
-
-<summary>Expand to see documentation on the options</summary>
+## `render` Options
 
 You wont often need to specify options, but if you ever do, here are the
 available options which you could provide as a second argument to `render`.
 
-**container**: By default, `react-testing-library` will create a `div` and
-append that div to the `document.body` and this is where your react component
-will be rendered. If you provide your own HTMLElement `container` via this
-option, it will not be appended to the `document.body` automatically.
+### `container`
+
+By default, `react-testing-library` will create a `div` and append that div to
+the `document.body` and this is where your react component will be rendered. If
+you provide your own HTMLElement `container` via this option, it will not be
+appended to the `document.body` automatically.
 
 For Example: If you are unit testing a `tablebody` element, it cannot be a child
 of a `div`. In this case, you can specify a `table` as the render `container`.
@@ -69,18 +73,26 @@ const { container } = render(<TableBody {...props} />, {
 })
 ```
 
-**baseElement**: If the `container` is specified, then this defaults to that,
-otherwise this defaults to `document.documentElement`. This is used as the base
-element for the queries as well as what is printed when you use `debug()`.
+### `baseElement`
 
-**hydrate**: If hydrate is set to true, then it will render with
+If the `container` is specified, then this defaults to that, otherwise this
+defaults to `document.documentElement`. This is used as the base element for the
+queries as well as what is printed when you use `debug()`.
+
+### `hydrate`
+
+If hydrate is set to true, then it will render with
 [ReactDOM.hydrate](https://reactjs.org/docs/react-dom.html#hydrate). This may be
 useful if you are using server-side rendering and use ReactDOM.hydrate to mount
 your components.
 
-</details>
+### `wrapper`
 
----
+Pass a React Component as the `wrapper` option to have it rendered around the
+inner element. This is most useful for creating reusable custom render functions
+for common data providers. See [setup](setup.md#custom-render) for examples.
+
+## `render` Result
 
 The `render` method returns an object that has a few properties:
 
@@ -88,7 +100,7 @@ The `render` method returns an object that has a few properties:
 
 The most important feature of `render` is that the queries from
 [dom-testing-library](api-queries.md) are automatically returned with their
-first argument bound to the rendered container.
+first argument bound to the document.
 
 See [Queries](api-queries.md) for a complete list.
 
@@ -222,6 +234,8 @@ fireEvent.click(getByText(/Click to increase/))
 expect(firstRender).toMatchDiffSnapshot(asFragment())
 ```
 
+---
+
 ## `cleanup`
 
 Unmounts React trees that were mounted with [render](#render).
@@ -247,6 +261,8 @@ errors in your tests).
 that you configure your test framework to run a file before your tests which
 does this automatically. See the [setup](./setup) section for guidance on how to
 set up your framework.
+
+---
 
 ## `act`
 

--- a/docs/react-testing-library/api.md
+++ b/docs/react-testing-library/api.md
@@ -100,7 +100,8 @@ The `render` method returns an object that has a few properties:
 
 The most important feature of `render` is that the queries from
 [dom-testing-library](api-queries.md) are automatically returned with their
-first argument bound to the document.
+first argument bound to the [baseElement](#baseelement), which defaults to
+`document.body`.
 
 See [Queries](api-queries.md) for a complete list.
 


### PR DESCRIPTION
- Adds docs for render option "wrapper": https://github.com/kentcdodds/react-testing-library/pull/303
- Reorganizes the API and Setup pages for rtl slightly to add better heading structure for the right navbar.

Accidentally got remotes mixed up - this reverts the revert that prematurely merged the change.

This reverts commit c47aae0c8b92b71be73ac64cda0453f13c434642.