### PR TITLE
fix anchor link for render

### DIFF
--- a/docs/react-testing-library/api.md
+++ b/docs/react-testing-library/api.md
@@ -6,7 +6,7 @@ title: API
 `react-testing-library` re-exports everything from `dom-testing-library` as well
 as these methods:
 
-- [`render`](#act)
+- [`render`](#render)
 - [`cleanup`](#cleanup)
 - [`act`](#act)
 


### PR DESCRIPTION
Currently the anchor link for `render` navigates to `act`. See example [here](https://testing-library.com/docs/react-testing-library/api). This PR fixes this issue.