### PR TITLE
Removed dangling 'example-reach-transition-group' example from sidebar

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,6 +16,7 @@
       "example-react-redux",
       "example-react-router",
       "example-reach-router",
+      "example-react-transition-group",
       "example-external"
     ],
     "API": ["api-queries", "api-events", "api-async", "api-helpers"],

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,7 +16,6 @@
       "example-react-redux",
       "example-react-router",
       "example-reach-router",
-      "example-reach-transition-group",
       "example-external"
     ],
     "API": ["api-queries", "api-events", "api-async", "api-helpers"],


### PR DESCRIPTION
Hi friends,

I noticed when I was going through the docs, if you're on `/docs/example-reach-router` and you clicked the next button, you'd be lead to the 404 page. But clicking on `External Examples` in the sidebar brought you to the next page following the `Reach Router` example.

I took a look at the code and it looks like `example-reach-transition-group` is not a thing anymore. So I figured `example-reach-transition-group` might just be a dangling piece of code in `sidebars.json` and removed it.

Seems to do the trick. In the `Reach Router` doc the next button now takes the user to the expected `External Examples`.

**Button before:**

![Screen Shot 2019-03-22 at 10 59 01 AM](https://user-images.githubusercontent.com/25241230/54831879-8f521180-4c91-11e9-8a42-5c773394a77e.png)

**Button after change:**

![Screen Shot 2019-03-22 at 10 58 26 AM](https://user-images.githubusercontent.com/25241230/54831895-9547f280-4c91-11e9-8961-c514412881d8.png)

