### PR TITLE
Update react-testing-library cheatsheet typos

### DIFF
--- a/docs/dom-testing-library/cheatsheet.md
+++ b/docs/dom-testing-library/cheatsheet.md
@@ -68,12 +68,12 @@ See [Which query should I use?](guide-which-query.md)
   - findByRole
   - findAllByRole
 - **ByTestId** find by data-testid attribute
-  - getByPlaceholderText
-  - queryByPlaceholderText
-  - getAllByPlaceholderText
-  - queryAllByPlaceholderText
-  - findByPlaceholderText
-  - findAllByPlaceholderText
+  - getByTestId
+  - queryByTestId
+  - getAllByTestId
+  - queryAllByTestId
+  - findByTestId
+  - findAllByTestId
 
 ## Async
 

--- a/docs/react-testing-library/cheatsheet.md
+++ b/docs/react-testing-library/cheatsheet.md
@@ -95,12 +95,12 @@ See [Which query should I use?](guide-which-query.md)
   - findByRole
   - findAllByRole
 - **ByTestId** find by data-testid attribute
-  - getByPlaceholderText
-  - queryByPlaceholderText
-  - getAllByPlaceholderText
-  - queryAllByPlaceholderText
-  - findByPlaceholderText
-  - findAllByPlaceholderText
+  - getByTestId
+  - queryByTestId
+  - getAllByTestId
+  - queryAllByTestId
+  - findByTestId
+  - findAllByTestId
 
 ## Async
 


### PR DESCRIPTION
I noticed a few typos in the react-testing-library cheatsheet page.  For the https://testing-library.com/docs/react-testing-library/cheatsheet#queries section the **ByTestId** displays a copy of the placeholder content above it.

This PR updates these values to their correct naming.