### PR TITLE
fix typo in link on dom-testing-library/cheatsheet.md

### DIFF
--- a/docs/dom-testing-library/cheatsheet.md
+++ b/docs/dom-testing-library/cheatsheet.md
@@ -95,7 +95,7 @@ See [Events API](api-events.md)
 
 ## Other
 
-See [Helpers API](api-helpers.md), [Config API](api-configration.md)
+See [Helpers API](api-helpers.md), [Config API](api-configuration.md)
 
 - **within** take a node and return an object with all the queries bound to the
   node (used to return the queries from `react-testing-library`'s render


### PR DESCRIPTION
thanks for accepting my previous PR. I missed a typo in one of the links. This fixes the typo.